### PR TITLE
updated rqt2.repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RQT1
+# RQT2
 
 ## Setup
 
@@ -75,4 +75,4 @@ To see the C++ plugin interface in action run ``rqt_image_view`` with the follow
 
  - In another terminal:
 
-        ros2 run rqt_image_view image_publisher.py
+        ros2 run rqt_image_view image_publisher

--- a/rqt2.repos
+++ b/rqt2.repos
@@ -1,59 +1,59 @@
 repositories:
   rqt2/python_qt_binding:
     type: git
-    url: git@github.com:ros-visualization/python_qt_binding.git
+    url: https://github.com/ros-visualization/python_qt_binding.git
     version: crystal-devel
   rqt2/qt_gui_core:
     type: git
-    url: git@github.com:ros-visualization/qt_gui_core.git
-    version: rqt-gui-cpp-exp
+    url: https://github.com/ros-visualization/qt_gui_core.git
+    version: crystal-devel
   rqt2/rqt:
     type: git
-    url: git@github.com:ros-visualization/rqt.git
+    url: https://github.com/ros-visualization/rqt.git
     version: crystal-devel
   rqt2/rqt_msg:
     type: git
-    url: git@github.com:ros-visualization/rqt_msg.git
+    url: https://github.com/ros-visualization/rqt_msg.git
     version: crystal-devel
   rqt2/rqt_publisher:
     type: git
-    url: git@github.com:ros-visualization/rqt_publisher.git
+    url: https://github.com/ros-visualization/rqt_publisher.git
     version: crystal-devel
   rqt2/rqt_py_console:
     type: git
-    url: git@github.com:ros-visualization/rqt_py_console.git
+    url: https://github.com/ros-visualization/rqt_py_console.git
     version: crystal-devel
   rqt2/rqt_shell:
     type: git
-    url: git@github.com:ros-visualization/rqt_shell.git
+    url: https://github.com/ros-visualization/rqt_shell.git
     version: crystal-devel
   rqt2/rqt_srv:
     type: git
-    url: git@github.com:ros-visualization/rqt_srv.git
+    url: https://github.com/ros-visualization/rqt_srv.git
     version: crystal-devel
   rqt2/rqt_console:
     type: git
-    url: git@github.com:ros-visualization/rqt_console.git
+    url: https://github.com/ros-visualization/rqt_console.git
     version: crystal-devel
 #  rqt2/rqt_service_caller:
 #    type: git
-#    url: git@github.com:ros-visualization/rqt_service_caller.git
+#    url: https://github.com/ros-visualization/rqt_service_caller.git
 #    version: crystal-devel
 
   # RQT image view
   rqt2/rqt_image_view:
     type: git
-    url: git@github.com:ros-visualization/rqt_image_view.git
-    version: ros2-port
+    url: https://github.com/ros-visualization/rqt_image_view.git
+    version: crystal-devel
   ros-perception/image_common:
     type: git
-    url: git@github.com:ros-perception/image_common.git
+    url: https://github.com/ros-perception/image_common.git
     version: ros2
   ros2/message_filters:
     type: git
-    url: git@github.com:ros2/message_filters.git
+    url: https://github.com/ros2/message_filters.git
     version: master
   ros-perception/vision_opencv:
     type: git
-    url: git@github.com:ros-perception/vision_opencv.git
+    url: https://github.com/ros-perception/vision_opencv.git
     version: ros2


### PR DESCRIPTION
I tried to build rqt2.
However when I run `vcs import src --force < rqt2.repos` it keeps asking whether I want to add the repos to the list of known hosts.
After answering `yes` several times, the terminal moves on but all the imports fail.

I have updated the `rqt2.repos` file, specifying the URL as done for the [ros2.repos](https://github.com/ros2/ros2/blob/master/ros2.repos) and now it works fine.
I also had to rename a couple branches as they were not existing in the target repositories.

Moreover I corrected a couple of typos in the README.